### PR TITLE
Improve config.py to consume enviroment variables.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,10 +2,10 @@ from os import environ as env
 
 SERVER_HOST = "0.0.0.0"
 SERVER_PORT = 8002
-AUTH = env.get("BOT_API_AUTH", "oof")
+AUTH = env.get("BOT_API_AUTH", "")
 DEBUG_MODE = env.get("PROD") != "TRUE"
 
-REDIS_HOST = ""
+REDIS_HOST = env.get("REDIS_HOST")
 REDIS_PORT = 6379
-REDIS_PASSWORD = ""
-MONGO_URL  = ""
+REDIS_PASSWORD = env.get("REDIS_PASSWORD", "")
+MONGO_URL = env.get("MONGO_URL", "")

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@ SERVER_PORT = 8002
 AUTH = env.get("BOT_API_AUTH", "")
 DEBUG_MODE = env.get("PROD") != "TRUE"
 
-REDIS_HOST = env.get("REDIS_HOST")
+REDIS_HOST = env.get("REDIS_HOST", "")
 REDIS_PORT = 6379
 REDIS_PASSWORD = env.get("REDIS_PASSWORD", "")
 MONGO_URL = env.get("MONGO_URL", "")


### PR DESCRIPTION
A simple merge, allowing for environment variables to substitute for config.py changes.

* REDIS_PORT, SERVER_PORT, and SERVER_HOST are all kept non-env configurable.